### PR TITLE
Fix scrolling in topic tree and message list views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "mqtop"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtop"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "High-performance MQTT explorer TUI - like htop for your broker"
 authors = ["Sourceful Energy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,7 +359,7 @@ async fn run_app(config: Config, config_path: PathBuf, needs_server_setup: bool)
     // Main loop
     loop {
         // Draw UI
-        terminal.draw(|f| ui::render(f, &app))?;
+        terminal.draw(|f| ui::render(f, &mut app))?;
 
         // Handle events with timeout
         let timeout = tick_rate;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -31,7 +31,7 @@ pub use stats_view::render_stats;
 pub use tree_view::render_tree;
 
 /// Main render function
-pub fn render(frame: &mut Frame, app: &App) {
+pub fn render(frame: &mut Frame, app: &mut App) {
     let size = frame.area();
 
     // Create main layout: header, content, footer


### PR DESCRIPTION
The ListState was being created fresh on every render with default offset=0, causing the scroll position to reset. This prevented users from scrolling through large lists of topics.

Changes:
- Update tree_view to track scroll offset and ensure selection is visible
- Update message_view with same scroll behavior
- Persist scroll offset in App state (tree_scroll, message_scroll)
- Pass mutable App reference to render functions

Fixes #1